### PR TITLE
Add svm classifier

### DIFF
--- a/svm/__main__.py
+++ b/svm/__main__.py
@@ -5,6 +5,7 @@ from svm.utils import download_mnist_dataset, visualize_batch, visualize_image, 
 from torch import nn
 from svm.SVM_Model import SVMModel
 import svm.knn_classifier as knn
+import svm.svm_classifier as svm
 
 if __name__ == "__main__":
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -60,3 +61,5 @@ if __name__ == "__main__":
 
     print(f"Running K-nearest centroid classification\n")
     knn.centroid_classification(train_df, train_label, test_df, test_label)
+    print(f"Running support vector machine classification. This can take hours depending on your machine...")
+    svm.main()

--- a/svm/__main__.py
+++ b/svm/__main__.py
@@ -44,4 +44,19 @@ if __name__ == "__main__":
     mnist_model.to(device)
     print(f"Training took {stopwatch(lambda: train(model=mnist_model, device=device, train_loader=train_loader, criterion=criterion, optimizer=optimizer, epochs=n_epochs))}s")
     print(f"Evaluation took {stopwatch(lambda: evaluate(model=mnist_model, device=device, test_loader=test_loader, criterion=criterion, labels=labels))}s")
-    knn.main()
+
+    # transform data to numpy arrays
+    train_df = train_set.data.numpy()
+    train_label = train_set.targets.numpy()
+    train_df = np.reshape(train_df, (train_df.shape[0], train_df.shape[1] * train_df.shape[2]))
+
+    test_df = test_set.data.numpy()
+    test_label = test_set.targets.numpy()
+    test_df = np.reshape(test_df, (test_df.shape[0], test_df.shape[1] * test_df.shape[2]))
+
+    for k in range(1, 4, 2):
+        print(f"Running KNN classification for {k} nearest neighbor(s)\n")
+        knn.knn_classification(train_df, train_label, test_df, test_label, k)
+
+    print(f"Running K-nearest centroid classification\n")
+    knn.centroid_classification(train_df, train_label, test_df, test_label)

--- a/svm/svm_classifier.py
+++ b/svm/svm_classifier.py
@@ -1,0 +1,55 @@
+import os
+import time
+from sklearn.svm import SVC
+from sklearn.model_selection import GridSearchCV
+from svm.utils import download_mnist_dataset, split_into_even_and_odd
+import numpy as np
+import pandas as pd
+from sklearn.metrics import classification_report
+from sklearn.preprocessing import scale
+
+
+def svm_classifier(train_set, train_labels, test_set, test_labels):
+    start_time = time.time()
+    grid_params = {
+        'gamma': [1e-2, 1e-3, 1e-4],
+        'C': [5, 10]
+    }
+    X_train = scale(train_set)
+    X_test = scale(test_set)
+    svc = SVC(kernel='rbf', shrinking=True, cache_size=1000, random_state=42)
+    grid = GridSearchCV(svc, grid_params, refit=True, n_jobs=-1, verbose=5)
+    grid.fit(X_train, train_labels)
+    print(f"Training Time: {(time.time() - start_time)} seconds.")
+    start_time = time.time()
+    pred = grid.predict(X_test)
+    print(f"Prediction Time: {(time.time() - start_time)} seconds.")
+    clf = grid.best_estimator_
+    print(f"Best estimator was {grid.best_params_}")
+    start_time = time.time()
+    clf.score(X_test, test_labels)
+    print(f"Prediction time for best estimator: {(time.time() - start_time)} seconds.")
+    print(pd.DataFrame(grid.cv_results_))
+    report_nc = classification_report(test_labels, pred)
+    print(report_nc)
+
+
+def main():
+    train_dataset = download_mnist_dataset('mnist', True, transform=None)
+    split_into_even_and_odd(train_dataset)
+    train_df = train_dataset.data.numpy()
+    train_label = train_dataset.targets.numpy()
+
+    train_df = np.reshape(train_df, (train_df.shape[0], train_df.shape[1] * train_df.shape[2]))
+
+    test_dataset = download_mnist_dataset('mnist', False, transform=None)
+    split_into_even_and_odd(test_dataset)
+    test_df = test_dataset.data.numpy()
+    test_label = test_dataset.targets.numpy()
+
+    test_df = np.reshape(test_df, (test_df.shape[0], test_df.shape[1] * test_df.shape[2]))
+    svm_classifier(train_df, train_label, test_df, test_label)
+
+
+if __name__ == '__main__':
+    main()

--- a/svm/utils.py
+++ b/svm/utils.py
@@ -23,7 +23,7 @@ def visualize_batch(train_loader):
         ax.imshow(np.squeeze(images[idx]), cmap='gray')
         # print out the correct label for each image
         # .item() gets the value contained in a Tensor
-        ax.set_title(str(labels[idx].item()))
+        ax.set_title(str('even' if labels[idx].item() == 0 else 'odd'))
 
     plt.show()
 


### PR DESCRIPTION
This adds a grid search for finding the best parameters for a svm classifier. It performs a 5 fold search for each combination of parameters (6 combinations * 5 folds = 30 fits). When done, it gets the best combination of parameters based on its score and runs the prediction method on it.

Depending on the hardware it can take hours to complete

here is a sample output with the worst times for the fitting
```
[CV 4/5] END ..................C=5, gamma=0.01;, score=0.936 total time=290.0min
[CV 2/5] END ..................C=5, gamma=0.01;, score=0.927 total time=290.9min
[CV 1/5] END ..................C=5, gamma=0.01;, score=0.934 total time=293.0min
[CV 5/5] END ..................C=5, gamma=0.01;, score=0.936 total time=293.0min
[CV 3/5] END ..................C=5, gamma=0.01;, score=0.938 total time=293.6min
```
(they are out of order as they run in parallel threads and the others are completed first)

The more CPU cores and ram the better for the grid search